### PR TITLE
Solucion alterna

### DIFF
--- a/app/controllers/poll_headers_controller.rb
+++ b/app/controllers/poll_headers_controller.rb
@@ -61,7 +61,7 @@ class PollHeadersController < ApplicationController
   private
   # Use callbacks to share common setup or constraints between actions.
   def set_poll_header
-    @poll_header = PollHeader.find_by(params[:id])
+    @poll_header = PollHeader.find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.
@@ -71,5 +71,7 @@ class PollHeadersController < ApplicationController
 
     # parametros obligatorios para el manejo en base de datos
     params.require(:poll_header).permit(:age, :date, :gender_id, :institution_id)
+
+    # invocar todos los create desde el mismo controlador
   end
 end

--- a/app/controllers/poll_headers_controller.rb
+++ b/app/controllers/poll_headers_controller.rb
@@ -22,7 +22,7 @@ class PollHeadersController < ApplicationController
   # POST /poll_headers
   # POST /poll_headers.json
   def create
-    @poll_header = PollHeader.new(poll_header_params)
+    @poll_header = PollHeader.new(poll_header_params.merge(id: SecureRandom.hex(2)))
     respond_to do |format|
       if @poll_header.save
         format.html { redirect_to @poll_header, notice: 'Poll header was successfully created.' }
@@ -66,9 +66,10 @@ class PollHeadersController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def poll_header_params
-    # id = SecureRandom.hex 2
     # asignar un valor de id aleatorio para el almacenamiento del poll_header en la base de datos
-    params[:poll_header][:id] = SecureRandom.hex 2
-    params.require(:poll_header).permit(:id, :age, :date, :gender_id, :institution_id)
+    # params[:poll_header][:id] = SecureRandom.hex 2
+
+    # parametros obligatorios para el manejo en base de datos
+    params.require(:poll_header).permit(:age, :date, :gender_id, :institution_id)
   end
 end

--- a/app/controllers/poll_headers_controller.rb
+++ b/app/controllers/poll_headers_controller.rb
@@ -9,8 +9,7 @@ class PollHeadersController < ApplicationController
 
   # GET /poll_headers/1
   # GET /poll_headers/1.json
-  def show
-  end
+  def show; end
 
   # GET /poll_headers/new
   def new
@@ -18,14 +17,12 @@ class PollHeadersController < ApplicationController
   end
 
   # GET /poll_headers/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /poll_headers
   # POST /poll_headers.json
   def create
     @poll_header = PollHeader.new(poll_header_params)
-
     respond_to do |format|
       if @poll_header.save
         format.html { redirect_to @poll_header, notice: 'Poll header was successfully created.' }
@@ -62,13 +59,16 @@ class PollHeadersController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_poll_header
-      @poll_header = PollHeader.find_by(params[:id])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_poll_header
+    @poll_header = PollHeader.find_by(params[:id])
+  end
 
-    # Only allow a list of trusted parameters through.
-    def poll_header_params
-      params.require(:poll_header).permit(:id, :age, :date, :gender_id, :institution_id)
-    end
+  # Only allow a list of trusted parameters through.
+  def poll_header_params
+    # id = SecureRandom.hex 2
+    # asignar un valor de id aleatorio para el almacenamiento del poll_header en la base de datos
+    params[:poll_header][:id] = SecureRandom.hex 2
+    params.require(:poll_header).permit(:id, :age, :date, :gender_id, :institution_id)
+  end
 end

--- a/app/views/poll_bodies/index.html.haml
+++ b/app/views/poll_bodies/index.html.haml
@@ -13,7 +13,7 @@
   %tbody
     - @poll_bodies.each do |poll_body|
       %tr
-        %td= poll_body.poll_header.code
+        %td= poll_body.poll_header.id
         %td= poll_body.question.detail
         %td= poll_body.category_replay.replay.description
         %td= link_to 'Show', poll_body

--- a/app/views/poll_headers/_form.html.haml
+++ b/app/views/poll_headers/_form.html.haml
@@ -4,7 +4,6 @@
   = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
   .form-inputs
-    = f.input :id
     = f.input :age
     = f.input :date
     = f.association :gender

--- a/app/views/poll_headers/index.html.haml
+++ b/app/views/poll_headers/index.html.haml
@@ -20,10 +20,7 @@
         %td= poll_header.date
         %td= poll_header.gender.name
         %td= poll_header.institution.name
-        %td= link_to 'Show', poll_header
-        %td= link_to 'Edit', edit_poll_header_path(poll_header)
-        %td= link_to 'Destroy', poll_header, :method => :delete, :data => { :confirm => 'Are you sure?' }
-
+        %td= link_to 'Group fields', new_group_field_path
 %br
 
 = link_to 'New Poll header', new_poll_header_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   resources :poll_bodies
   resources :group_fields
-  resources :poll_headers, param: :code
+  resources :poll_headers
+  #param: :code
   resources :questions
   resources :indicators
   resources :category_answers


### PR DESCRIPTION
Generar id desde el controlador y almacenar el poll_header, mediante modificacion del request

Actualizacion del paso anterior
Key aleatoria sin modificar el request enviado por la vista, a traves del metodo merge del hash, aplicando con esto mejores practicas

Ajustando el de find_by a find en el controlador de poll_header, eliminando param: :code en el routes
